### PR TITLE
Add connection and pool limits to backend database URL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       APP_VERSION: ${APP_VERSION:-0.1.0}
       
       # Database Configuration
-      DATABASE_URL: postgresql://ssalgten:${DB_PASSWORD:-ssalgten_password}@database:5432/ssalgten
+      DATABASE_URL: "postgresql://ssalgten:${DB_PASSWORD:-ssalgten_password}@database:5432/ssalgten?connection_limit=30&pool_timeout=30"
       
       # JWT Configuration
       JWT_SECRET: ${JWT_SECRET:-your-super-secret-jwt-key-change-this-in-production}


### PR DESCRIPTION
## Summary
- set backend DATABASE_URL to include `connection_limit=30` and `pool_timeout=30`

## Testing
- `npm test` *(fails: Missing script "test")*
- `docker compose config` *(fails: command not found: docker)*
- `docker compose up -d backend` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68b27c3a3ab48327a330ffad629f0e94